### PR TITLE
feat: 부하 주입을 위한 gatling 모듈 생성

### DIFF
--- a/throttling-example/build.gradle.kts
+++ b/throttling-example/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("spring-boot-convention")
+    id("io.gatling.gradle") version "3.13.5.1"
 }
 
 dependencies {

--- a/throttling-example/src/gatling/kotlin/kr/co/taek/dev/throttling/example/gatling/endpoints/APIEndpoints.kt
+++ b/throttling-example/src/gatling/kotlin/kr/co/taek/dev/throttling/example/gatling/endpoints/APIEndpoints.kt
@@ -1,0 +1,15 @@
+package kr.co.taek.dev.throttling.example.gatling.endpoints
+
+import io.gatling.javaapi.core.CoreDsl.StringBody
+import io.gatling.javaapi.http.HttpDsl.http
+import io.gatling.javaapi.http.HttpDsl.status
+import io.gatling.javaapi.http.HttpRequestActionBuilder
+
+object APIEndpoints {
+    val echo: HttpRequestActionBuilder = http("Echo API - #{tier}")
+        .post("/echo")
+        .header("X-API-KEY", "#{apiKey}")
+        .body(StringBody("#{message}"))
+        .asJson()
+        .check(status().`is`(200))
+}

--- a/throttling-example/src/gatling/kotlin/kr/co/taek/dev/throttling/example/gatling/simulations/EchoSimulations.kt
+++ b/throttling-example/src/gatling/kotlin/kr/co/taek/dev/throttling/example/gatling/simulations/EchoSimulations.kt
@@ -1,0 +1,27 @@
+package kr.co.taek.dev.throttling.example.gatling.simulations
+
+import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
+import io.gatling.javaapi.core.CoreDsl.jsonFile
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import kr.co.taek.dev.throttling.example.gatling.endpoints.APIEndpoints
+import java.time.Duration
+
+class EchoSimulations: Simulation() {
+    private val feeder = jsonFile("data/echo_messages.json").circular()
+
+    private val scn = scenario("Echo Load Test")
+        .feed(feeder)
+        .exec(APIEndpoints.echo)
+
+    init {
+        setUp(
+            scn.injectOpen(
+                constantUsersPerSec(50.0).during(Duration.ofSeconds(60))
+            )
+        ).protocols(
+            http.baseUrl("http://localhost:10000")
+        )
+    }
+}

--- a/throttling-example/src/gatling/resources/data/echo_messages.json
+++ b/throttling-example/src/gatling/resources/data/echo_messages.json
@@ -1,0 +1,5 @@
+[
+  {"tier": "FREE", "apiKey": "FREE-12345678", "message": "Hello, Free User!"},
+  {"tier": "STANDARD", "apiKey": "STD-23456789", "message": "Hello, Standard User!" },
+  {"tier": "PREMIUM", "apiKey": "PREM-23456789", "message": "Hello, Premium User!" }
+]

--- a/throttling-example/src/gatling/resources/logback.xml
+++ b/throttling-example/src/gatling/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+        </encoder>
+        <immediateFlush>false</immediateFlush>
+    </appender>
+
+    <!-- uncomment and set to DEBUG to log all failing HTTP requests -->
+    <!-- uncomment and set to TRACE to log all HTTP requests -->
+    <!--<logger name="io.gatling.http.engine.response" level="TRACE" />-->
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/throttling-example/src/main/kotlin/kr/co/taek/dev/throttling/example/bucket4j/rest/controller/EchoApiController.kt
+++ b/throttling-example/src/main/kotlin/kr/co/taek/dev/throttling/example/bucket4j/rest/controller/EchoApiController.kt
@@ -18,11 +18,6 @@ class EchoApiController(
         @RequestHeader("X-API-KEY") apiKey: String,
         @RequestBody message: String
     ): ResponseEntity<String> {
-
-        return try {
-            ResponseEntity.ok(echoService.echo(apiKey, message))
-        } catch (e: Exception) {
-            ResponseEntity.status(429).body("API 사용량을 초과하였습니다.")
-        }
+        return ResponseEntity.ok(echoService.echo(apiKey, message))
     }
 }

--- a/throttling-example/src/main/kotlin/kr/co/taek/dev/throttling/example/bucket4j/rest/filter/PricingPlanLimitFilter.kt
+++ b/throttling-example/src/main/kotlin/kr/co/taek/dev/throttling/example/bucket4j/rest/filter/PricingPlanLimitFilter.kt
@@ -2,6 +2,7 @@ package kr.co.taek.dev.throttling.example.bucket4j.rest.filter
 
 import io.github.bucket4j.Bandwidth
 import io.github.bucket4j.Bucket
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.Filter
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletRequest
@@ -12,6 +13,8 @@ import kr.co.taek.dev.throttling.example.bucket4j.rest.enumeration.PricingPlan
 import org.springframework.stereotype.Component
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+
+private val logger = KotlinLogging.logger { }
 
 @Component
 class PricingPlanLimitFilter : Filter {
@@ -33,6 +36,7 @@ class PricingPlanLimitFilter : Filter {
             httpResponse.status = 429
             httpResponse.addHeader("X-Rate-Limit-Retry-After-Millis", TimeUnit.NANOSECONDS.toMillis(probe.nanosToWaitForRefill).toString())
             httpResponse.writer.write("Too Many Requests")
+            logger.warn { "Rate limit exceeded!" }
         }
     }
     private fun resolveBucket(apiKey: String): Bucket {


### PR DESCRIPTION
## 1. Pricing Plan 설정 정리
<img width="461" alt="image" src="https://github.com/user-attachments/assets/e9b32a9a-5d5e-4ec7-8c3c-93629d805110" />

## 2. 실제 테스트 조건
- 시뮬레이션 TPS : 50.0 TPS
- 실행시간 : 60s
- 총 요청수 : 3000
- tier별로 feader에서 동일한 비율로 순환 -> 각 tier에 1000건씩 분배

## 3. Gatling 리포트 결과 정리
<img width="557" alt="image" src="https://github.com/user-attachments/assets/1e8fc1c3-7922-4151-bb60-d2f59172a614" />

## 4. 실제 콘솔 결과
<img width="778" alt="image" src="https://github.com/user-attachments/assets/2e1247cf-f503-4d84-9a49-30e1a7b29f43" />
